### PR TITLE
PHP 7.3 Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 php
-mysql
+sql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM php:5.6-apache
+FROM php:7.3-apache
 
 RUN docker-php-ext-install mysqli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       volumes:
         - ./php:/var/www/html
       ports:
-        - "8080":"80"
+        - "8080:80"
       links:
         - db
     db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,16 @@
-web:
-  build: .
-  volumes:
-    - ./php:/var/www/html
-  ports:
-    - 8080:80
-  links:
-    - db
-db:
-  image: mysql
-  volumes:
-    - ./mysql:/var/lib/mysql
-  environment:
-    MYSQL_ROOT_PASSWORD: guest
+version: "3.7"
+services:
+    web:
+      build: .
+      volumes:
+        - ./php:/var/www/html
+      ports:
+        - "8080":"80"
+      links:
+        - db
+    db:
+      image: mysql
+      volumes:
+        - ./mysql:/var/lib/mysql
+      environment:
+        MYSQL_ROOT_PASSWORD: guest


### PR DESCRIPTION
PHP 5.6 has now reached end of life: https://www.php.net/supported-versions.php

It is strongly recommended to not use this version of PHP in any new projects, as such this updates to 7.3 (current stable version until Jan 2021).